### PR TITLE
Enable shared library builds and improve CMake script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,6 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     target_compile_options(OpenCLRuntimeLoader PRIVATE /EHsc)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_compile_options(OpenCLRuntimeLoader PRIVATE -Wall)
-    set_target_properties(OpenCLRuntimeLoader PROPERTIES LINK_FLAGS "-Wl,--version-script")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     # TODO
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(OpenCLRuntimeLoader PUBLIC ${OpenCL_INCLUDE_DIRS})
 target_compile_definitions(OpenCLRuntimeLoader PRIVATE CL_TARGET_OPENCL_VERSION=300)
 target_link_libraries(OpenCLRuntimeLoader PRIVATE ${CMAKE_DL_LIBS})
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+if(MSVC)
     target_compile_options(OpenCLRuntimeLoader PRIVATE /EHsc)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_compile_options(OpenCLRuntimeLoader PRIVATE -Wall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ set(CMAKE_CXX_STANDARD 11)
 
 project(OpenCLRuntimeLoader LANGUAGES C CXX)
 
+option(BUILD_SHARED_LIBS "Set to ON to build a shared library." OFF)
+
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     include(CTest)
 endif()
@@ -40,7 +42,7 @@ set( OpenCLRuntimeLoader_SOURCE_FILES
 
 source_group(Source FILES ${OpenCLRuntimeLoader_SOURCE_FILES})
 
-add_library(OpenCLRuntimeLoader STATIC ${OpenCLRuntimeLoader_SOURCE_FILES})
+add_library(OpenCLRuntimeLoader ${OpenCLRuntimeLoader_SOURCE_FILES})
 set_target_properties(OpenCLRuntimeLoader PROPERTIES FOLDER "OpenCLRuntimeLoader")
 target_include_directories(OpenCLRuntimeLoader PUBLIC ${OpenCL_INCLUDE_DIRS})
 target_compile_definitions(OpenCLRuntimeLoader PRIVATE CL_TARGET_OPENCL_VERSION=300)


### PR DESCRIPTION
This PR contains various changes to the CMake build that make it a bit more flexible.

  * Adds the standard `BUILD_SHARED_LIBS` option that allows consumers to select a shared or static library. 
  * Removes the assumption that Windows == MSVC. This is not always true: one can build on Windows via mingw or cross-compile for Windows similarly. In that case, the compiler won't understand the MSVC flag.

There was an incomplete link flag passed which caused the shared build to fail. The relevant section in the flags: ` -Wl,--version-script -shared -Wl,-soname,libOpenCLRuntimeLoader.so`

`--version-script` requires an argument, so the next linker option, `-soname` was treated as one, leading to this error:

```
cannot open linker script file -soname: No such file or directory
```

I'm not sure what the intention was with this flag, maybe it was a copy-paste error? In any case, this allows building the library in both a shared and static configuration.