### PR TITLE
robustness improvements

### DIFF
--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -1537,7 +1537,14 @@ typedef HMODULE _sclModuleHandle;
 #define _sclGetFunctionAddress(_module, _name)  ::GetProcAddress(_module, _name)
 #else
 typedef void*   _sclModuleHandle;
-#define _sclOpenICDLoader()                     ::dlopen("libOpenCL.so", RTLD_LAZY | RTLD_LOCAL)
+static inline _sclModuleHandle _sclOpenICDLoader()
+{
+    _sclModuleHandle ret = ::dlopen("libOpenCL.so.1", RTLD_LAZY | RTLD_LOCAL);
+    if (ret == NULL) {
+        ret = ::dlopen("libOpenCL.so", RTLD_LAZY | RTLD_LOCAL);
+    }
+    return ret;
+}
 #define _sclCloseICDLoader(_module)             ::dlclose(_module)
 #define _sclGetFunctionAddress(_module, _name)  ::dlsym(_module, _name)
 #endif
@@ -1586,18 +1593,23 @@ CL_API_ENTRY cl_int CL_API_CALL clGetPlatformIDs(
     cl_platform_id* platforms,
     cl_uint* num_platforms)
 {
-    _sclModuleHandle module = _sclGetICDLoaderHandle();
-    _sclpfn_clGetPlatformIDs _clGetPlatformIDs =
-        (_sclpfn_clGetPlatformIDs)_sclGetFunctionAddress(
-            module, "clGetPlatformIDs");
-    _sclpfn_clGetExtensionFunctionAddressForPlatform _clGetExtensionFunctionAddressForPlatform =
-        (_sclpfn_clGetExtensionFunctionAddressForPlatform)_sclGetFunctionAddress(
-            module, "clGetExtensionFunctionAddressForPlatform");
-
     // Basic error checks:
     if ((platforms == NULL && num_entries != 0) ||
         (platforms == NULL && num_platforms == NULL)) {
         return CL_INVALID_VALUE;
+    }
+
+    _sclModuleHandle module = _sclGetICDLoaderHandle();
+    _sclpfn_clGetPlatformIDs _clGetPlatformIDs = NULL;
+    _sclpfn_clGetExtensionFunctionAddressForPlatform _clGetExtensionFunctionAddressForPlatform = NULL;
+
+    if (module) {
+        _clGetPlatformIDs =
+            (_sclpfn_clGetPlatformIDs)_sclGetFunctionAddress(
+                module, "clGetPlatformIDs");
+        _clGetExtensionFunctionAddressForPlatform =
+            (_sclpfn_clGetExtensionFunctionAddressForPlatform)_sclGetFunctionAddress(
+                module, "clGetExtensionFunctionAddressForPlatform");
     }
 
     if (_clGetPlatformIDs) {


### PR DESCRIPTION
Fixes #19
Fixes #20

## Description of Changes

This PR includes two changes to improve robustness:

1. In addition to `libOpenCL.so`, which is typically installed by "dev" packages, search for `libOpenCL.so.1` as well, which is typically installed by ICD loader packages.
2. If the ICD loader handle is not found, handle the case where dlopen or LoadLibrary returns `NULL`.

## Testing Done

Tested simple OpenCL samples with these changes.
