### PR TITLE
disable exceptions to ease linking with C applications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,9 @@ target_compile_definitions(OpenCLRuntimeLoader PRIVATE CL_TARGET_OPENCL_VERSION=
 target_link_libraries(OpenCLRuntimeLoader PRIVATE ${CMAKE_DL_LIBS})
 
 if(MSVC)
-    target_compile_options(OpenCLRuntimeLoader PRIVATE /EHsc)
+    target_compile_options(OpenCLRuntimeLoader PRIVATE /EHs-c-)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    target_compile_options(OpenCLRuntimeLoader PRIVATE -Wall)
+    target_compile_options(OpenCLRuntimeLoader PRIVATE -Wall -fno-exceptions)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     # TODO
 endif()


### PR DESCRIPTION
## Description of Changes

I believe this is the last remaining fix to break the dependency on the C++ STL (see #17).

This change disables exceptions, which are not used in this project, for both MSVC and other compilers.

## Testing Done

Verified that simple samples could run after this change.