### PR TITLE
add -Wall -fno-exceptions for all non-MSVC, not just for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,8 @@ target_link_libraries(OpenCLRuntimeLoader PRIVATE ${CMAKE_DL_LIBS})
 
 if(MSVC)
     target_compile_options(OpenCLRuntimeLoader PRIVATE /EHs-c-)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+else()
     target_compile_options(OpenCLRuntimeLoader PRIVATE -Wall -fno-exceptions)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    # TODO
 endif()
 
 include(GNUInstallDirs)


### PR DESCRIPTION
## Description of Changes

See comment: https://github.com/bashbaug/opencl-runtime-loader/commit/a8d027ba0185050e5c9e56d1866ee7806db93947#r43468905

Since we could be compiling with gcc or Clang on Windows, we should add `-Wall -fno-exceptions` for all non-MSVC cases, not just for Linux.

## Testing Done

Just code inspection - I have a Windows Clang install but I usually build with MSVC on Windows.
